### PR TITLE
Implement disk driver infrastructure

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -28,7 +28,7 @@ type VolumeDatabase interface {
 	Remove(volumeName string) error
 
 	// Mount a particular volume.
-	Mount(volumeName string, id string) (string, error)
+	Mount(volumeName string, id string, mountpoint string) error
 
 	// Unmount a particular volume.
 	Unmount(volumeName string, id string) error

--- a/db/inmemory.go
+++ b/db/inmemory.go
@@ -128,10 +128,10 @@ func (i InMemoryVolumeDatabase) Remove(volumeName string) error {
 }
 
 // Mount the specified volume to the host and increment the id to prevent premature removal, returning an error if one occured.
-func (i InMemoryVolumeDatabase) Mount(volumeName string, id string) (string, error) {
+func (i InMemoryVolumeDatabase) Mount(volumeName string, id string, mountpoint string) error {
 	vol, err := i.Get(volumeName)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	var exists bool
@@ -148,10 +148,9 @@ func (i InMemoryVolumeDatabase) Mount(volumeName string, id string) (string, err
 		i.mounts[volumeName][id] = 1
 	}
 
-	mountpoint := "/fake/location/" + volumeName
 	vol.Mountpoint = mountpoint
 	glog.Info(volumeName, " and id ", id, " is now has ", i.mounts[volumeName][id], " connections to "+mountpoint)
-	return mountpoint, nil
+	return nil
 }
 
 // Unmount the specified volume if the ids are no longer referencing it, returning an error if one occured.

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -36,6 +36,7 @@ type VolumeDatabaseQueries struct {
 	mountsDeleteByVolumeIDAndRequesterSQL       string
 }
 
+// DefaultSQLQueries stores the default SQL functions for sqldbs to use.
 var DefaultSQLQueries = VolumeDatabaseQueries{
 	// Volumes SQL statments
 	volumesCreateTableSQL: `CREATE TABLE IF NOT EXISTS volumes (
@@ -63,6 +64,7 @@ var DefaultSQLQueries = VolumeDatabaseQueries{
 }
 
 // NewSQLVolumeDatabase creates a new SQLVolumeDatabase, saving the database at dbPath.
+// Overide default sql queries by passing a VolumeDatabaseQueries object. Non-nil fields will be be used instead of the defaults.
 func NewSQLVolumeDatabase(dbType string, dbDataSource string, dbQueries VolumeDatabaseQueries) SQLVolumeDatabase {
 
 	queries := dbQueries.merge(DefaultSQLQueries)
@@ -130,28 +132,28 @@ func (s SQLVolumeDatabase) Create(volumeName string, options map[string]string) 
 	}
 
 	// Begin transaction to the database
-	tx, err := sqlDB.Begin()
+	transaction, err := sqlDB.Begin()
 	if err != nil {
 		return err
 	}
 
 	// Prepare the query
-	stmt, err := tx.Prepare(s.DBQueries.volumesInsertSQL)
+	preparedStatement, err := transaction.Prepare(s.DBQueries.volumesInsertSQL)
 	if err != nil {
-		tx.Rollback()
+		transaction.Rollback()
 		return err
 	}
-	defer stmt.Close()
+	defer preparedStatement.Close()
 
 	// Actually make the insert
-	_, err = stmt.Exec(volumeName)
+	_, err = preparedStatement.Exec(volumeName)
 	if err != nil {
-		tx.Rollback()
+		transaction.Rollback()
 		return err
 	}
 
 	// Commit the change
-	return tx.Commit()
+	return transaction.Commit()
 }
 
 // List all volumes
@@ -218,14 +220,14 @@ func (s SQLVolumeDatabase) getVolumeByName(volumeName string) (*volume.Volume, i
 	s.VerifyOrCrash()
 
 	// Prepare the query
-	stmt, err := sqlDB.Prepare(s.DBQueries.volumesGetVolumeByNameSQL)
+	preparedStatement, err := sqlDB.Prepare(s.DBQueries.volumesGetVolumeByNameSQL)
 	if err != nil {
 		return nil, 0, err
 	}
-	defer stmt.Close()
+	defer preparedStatement.Close()
 
 	// Query the database about the volumes
-	rows, err := stmt.Query(volumeName)
+	rows, err := preparedStatement.Query(volumeName)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -301,39 +303,39 @@ func (s SQLVolumeDatabase) Remove(volumeName string) error {
 	}
 
 	// Begin transaction to the database
-	tx, err := sqlDB.Begin()
+	transaction, err := sqlDB.Begin()
 	if err != nil {
 		return err
 	}
 
 	// Prepare the queries
-	stmtM, err := tx.Prepare(s.DBQueries.mountsDeleteByVolumeIDSQL)
+	mountsPreparedStatement, err := transaction.Prepare(s.DBQueries.mountsDeleteByVolumeIDSQL)
 	if err != nil {
 		return err
 	}
-	defer stmtM.Close()
+	defer mountsPreparedStatement.Close()
 
-	stmtV, err := tx.Prepare(s.DBQueries.volumesDeleteByIDSQL)
+	volumesPreparedStatement, err := transaction.Prepare(s.DBQueries.volumesDeleteByIDSQL)
 	if err != nil {
 		return err
 	}
-	defer stmtV.Close()
+	defer volumesPreparedStatement.Close()
 
 	// Actually make the deletes
-	_, err = stmtM.Exec(id)
+	_, err = mountsPreparedStatement.Exec(id)
 	if err != nil {
-		tx.Rollback()
+		transaction.Rollback()
 		return err
 	}
 
-	_, err = stmtV.Exec(id)
+	_, err = volumesPreparedStatement.Exec(id)
 	if err != nil {
-		tx.Rollback()
+		transaction.Rollback()
 		return err
 	}
 
 	// Commit the change
-	return tx.Commit()
+	return transaction.Commit()
 }
 
 // Mount the volume with name and id
@@ -349,53 +351,54 @@ func (s SQLVolumeDatabase) Mount(volumeName string, id string, mointpoint string
 	}
 
 	// Begin transaction to the database
-	tx, err := sqlDB.Begin()
+	transaction, err := sqlDB.Begin()
 	if err != nil {
 		return err
 	}
 
 	if vol.Mountpoint == "" {
 		vol.Mountpoint = mointpoint
-		stmtUp, errUp := tx.Prepare(s.DBQueries.volumesUpdateMountpointSQL)
+		volumeMountPointPreparedStatement, errUp := transaction.Prepare(s.DBQueries.volumesUpdateMountpointSQL)
 		if errUp != nil {
 			return errUp
 		}
-		defer stmtUp.Close()
+		defer volumeMountPointPreparedStatement.Close()
 
-		_, errUp = stmtUp.Exec(vol.Mountpoint, volid)
+		_, errUp = volumeMountPointPreparedStatement.Exec(vol.Mountpoint, volid)
 		if errUp != nil {
-			tx.Rollback()
+			transaction.Rollback()
 			return errUp
 		}
 	}
 
 	var newCount int
-	var q string
-	number, exists := mounts[id]
+	var updateOrInsertQuery string
+	numberOfMounts, exists := mounts[id]
 	if exists {
 		// Need to update the value to number + 1
-		newCount = number + 1
-		q = s.DBQueries.mountsUpdateCountByVolumeIDAndRequesterSQL
+		newCount = numberOfMounts + 1
+		updateOrInsertQuery = s.DBQueries.mountsUpdateCountByVolumeIDAndRequesterSQL
 	} else {
 		// Need to insert
 		newCount = 1
-		q = s.DBQueries.mountsInsertSQL
+		updateOrInsertQuery = s.DBQueries.mountsInsertSQL
 	}
 
-	stmt, err := tx.Prepare(q)
+	mountPreparedStatement, err := transaction.Prepare(updateOrInsertQuery)
 	if err != nil {
+		transaction.Rollback()
 		return err
 	}
-	defer stmt.Close()
+	defer mountPreparedStatement.Close()
 
-	_, err = stmt.Exec(newCount, volid, id)
+	_, err = mountPreparedStatement.Exec(newCount, volid, id)
 	if err != nil {
-		tx.Rollback()
+		transaction.Rollback()
 		return err
 	}
 
 	// Commit the change
-	return tx.Commit()
+	return transaction.Commit()
 }
 
 // Unmount volume with name and id
@@ -411,64 +414,64 @@ func (s SQLVolumeDatabase) Unmount(volumeName string, id string) error {
 	}
 
 	// Begin transaction to the database
-	tx, err := sqlDB.Begin()
+	transaction, err := sqlDB.Begin()
 	if err != nil {
 		return err
 	}
 
 	var newCount int
-	number, exists := mounts[id]
+	numberOfMounts, exists := mounts[id]
 	if exists {
-		if number > 1 {
+		if numberOfMounts > 1 {
 
 			// Need to update the value to number + 1
-			newCount = number - 1
-			stmt, err := tx.Prepare(s.DBQueries.mountsUpdateCountByVolumeIDAndRequesterSQL)
+			newCount = numberOfMounts - 1
+			preparedStatement, err := transaction.Prepare(s.DBQueries.mountsUpdateCountByVolumeIDAndRequesterSQL)
 			if err != nil {
 				return err
 			}
-			defer stmt.Close()
+			defer preparedStatement.Close()
 
-			_, err = stmt.Exec(newCount, volid, id)
+			_, err = preparedStatement.Exec(newCount, volid, id)
 			if err != nil {
-				tx.Rollback()
+				transaction.Rollback()
 				return err
 			}
 
 		} else {
 
 			// Need to delete
-			stmt, err := tx.Prepare(s.DBQueries.mountsDeleteByVolumeIDAndRequesterSQL)
+			preparedStatement, err := transaction.Prepare(s.DBQueries.mountsDeleteByVolumeIDAndRequesterSQL)
 			if err != nil {
 				return err
 			}
-			defer stmt.Close()
+			defer preparedStatement.Close()
 
-			_, err = stmt.Exec(volid, id)
+			_, err = preparedStatement.Exec(volid, id)
 			if err != nil {
-				tx.Rollback()
+				transaction.Rollback()
 				return err
 			}
 
-			stmtUp, errUp := tx.Prepare(s.DBQueries.volumesUpdateMountpointSQL)
-			if errUp != nil {
-				return errUp
+			volumeMountpointPreparedStatement, err := transaction.Prepare(s.DBQueries.volumesUpdateMountpointSQL)
+			if err != nil {
+				return err
 			}
-			defer stmtUp.Close()
+			defer volumeMountpointPreparedStatement.Close()
 
-			_, errUp = stmtUp.Exec("", volid)
-			if errUp != nil {
-				tx.Rollback()
-				return errUp
+			_, err = volumeMountpointPreparedStatement.Exec("", volid)
+			if err != nil {
+				transaction.Rollback()
+				return err
 			}
 		}
 	} else {
-		tx.Rollback()
+		transaction.Rollback()
 		return errors.New("Volume + ID was not mounted.")
 	}
 
 	// Commit the change
-	return tx.Commit()
+	return transaction.Commit()
 }
 
 // listMounts returns of all the IDs requesting the volume to be mounted and number of requests outstanding for that id.
@@ -480,14 +483,14 @@ func (s SQLVolumeDatabase) listMounts(volumeName string) (map[string]int, int, e
 	}
 
 	// Prepare the query
-	stmt, err := sqlDB.Prepare(s.DBQueries.mountsGetRequesterAndCountByVolumeIDListSQL)
+	preparedStatement, err := sqlDB.Prepare(s.DBQueries.mountsGetRequesterAndCountByVolumeIDListSQL)
 	if err != nil {
 		return nil, 0, err
 	}
-	defer stmt.Close()
+	defer preparedStatement.Close()
 
 	// Query the database about the volumes
-	rows, err := stmt.Query(id)
+	rows, err := preparedStatement.Query(id)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -526,32 +529,32 @@ func (s SQLVolumeDatabase) listMounts(volumeName string) (map[string]int, int, e
 	return mounts, sum, nil
 }
 
-func (dest VolumeDatabaseQueries) merge(src VolumeDatabaseQueries) VolumeDatabaseQueries {
+func (d VolumeDatabaseQueries) merge(defaults VolumeDatabaseQueries) VolumeDatabaseQueries {
 
-	update := func(dst string, src string) string {
-		if dst != "" {
-			return dst
+	update := func(overrideValue string, defaultValue string) string {
+		if overrideValue != "" {
+			return overrideValue
 		}
 
-		return src
+		return defaultValue
 	}
 
 	return VolumeDatabaseQueries{
 		// Volumes SQL statments
-		volumesCreateTableSQL:              update(dest.volumesCreateTableSQL, src.volumesCreateTableSQL),
-		volumesInsertSQL:                   update(dest.volumesInsertSQL, src.volumesInsertSQL),
-		volumesGetNameAndMountpointListSQL: update(dest.volumesGetNameAndMountpointListSQL, src.volumesGetNameAndMountpointListSQL),
-		volumesGetVolumeByNameSQL:          update(dest.volumesGetVolumeByNameSQL, src.volumesGetVolumeByNameSQL),
-		volumesUpdateMountpointSQL:         update(dest.volumesUpdateMountpointSQL, src.volumesUpdateMountpointSQL),
-		volumesDeleteByIDSQL:               update(dest.volumesDeleteByIDSQL, src.volumesDeleteByIDSQL),
+		volumesCreateTableSQL:              update(d.volumesCreateTableSQL, defaults.volumesCreateTableSQL),
+		volumesInsertSQL:                   update(d.volumesInsertSQL, defaults.volumesInsertSQL),
+		volumesGetNameAndMountpointListSQL: update(d.volumesGetNameAndMountpointListSQL, defaults.volumesGetNameAndMountpointListSQL),
+		volumesGetVolumeByNameSQL:          update(d.volumesGetVolumeByNameSQL, defaults.volumesGetVolumeByNameSQL),
+		volumesUpdateMountpointSQL:         update(d.volumesUpdateMountpointSQL, defaults.volumesUpdateMountpointSQL),
+		volumesDeleteByIDSQL:               update(d.volumesDeleteByIDSQL, defaults.volumesDeleteByIDSQL),
 
 		// Mounts SQL statements
-		mountsCreateTableSQL:                        update(dest.mountsCreateTableSQL, src.mountsCreateTableSQL),
-		mountsInsertSQL:                             update(dest.mountsInsertSQL, src.mountsInsertSQL),
-		mountsGetRequesterAndCountByVolumeIDListSQL: update(dest.mountsGetRequesterAndCountByVolumeIDListSQL, src.mountsGetRequesterAndCountByVolumeIDListSQL),
-		mountsUpdateCountByVolumeIDAndRequesterSQL:  update(dest.mountsUpdateCountByVolumeIDAndRequesterSQL, src.mountsUpdateCountByVolumeIDAndRequesterSQL),
-		mountsDeleteByVolumeIDSQL:                   update(dest.mountsDeleteByVolumeIDSQL, src.mountsDeleteByVolumeIDSQL),
-		mountsDeleteByVolumeIDAndRequesterSQL:       update(dest.mountsDeleteByVolumeIDAndRequesterSQL, src.mountsDeleteByVolumeIDAndRequesterSQL),
+		mountsCreateTableSQL:                        update(d.mountsCreateTableSQL, defaults.mountsCreateTableSQL),
+		mountsInsertSQL:                             update(d.mountsInsertSQL, defaults.mountsInsertSQL),
+		mountsGetRequesterAndCountByVolumeIDListSQL: update(d.mountsGetRequesterAndCountByVolumeIDListSQL, defaults.mountsGetRequesterAndCountByVolumeIDListSQL),
+		mountsUpdateCountByVolumeIDAndRequesterSQL:  update(d.mountsUpdateCountByVolumeIDAndRequesterSQL, defaults.mountsUpdateCountByVolumeIDAndRequesterSQL),
+		mountsDeleteByVolumeIDSQL:                   update(d.mountsDeleteByVolumeIDSQL, defaults.mountsDeleteByVolumeIDSQL),
+		mountsDeleteByVolumeIDAndRequesterSQL:       update(d.mountsDeleteByVolumeIDAndRequesterSQL, defaults.mountsDeleteByVolumeIDAndRequesterSQL),
 	}
 
 }

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -9,21 +9,23 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-// NewSQLiteVolumeDatabase creates a new SQLVolumeDatabase, saving the database at dbPath.
-func NewSQLiteVolumeDatabase(dbPath string) SQLVolumeDatabase {
-
-	var queries VolumeDatabaseQueries
-	queries.volumesCreateTableSQL = `CREATE TABLE IF NOT EXISTS volumes (
+// SQLiteSQLOverrides defines a list of qurries that need to differ from the defaults in order for sqlite to function correctly.
+var SQLiteSQLOverrides = VolumeDatabaseQueries{
+	volumesCreateTableSQL: `CREATE TABLE IF NOT EXISTS volumes (
         id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
         name TEXT NOT NULL UNIQUE,
         mountpoint TEXT
-    )`
+    )`,
 
-	queries.mountsCreateTableSQL = `CREATE TABLE IF NOT EXISTS mounts (
+	mountsCreateTableSQL: `CREATE TABLE IF NOT EXISTS mounts (
         volume_id INTEGER NOT NULL,
         requester_id TEXT NOT NULL,
         count INTEGER NOT NULL
-    )`
+    )`,
+}
+
+// NewSQLiteVolumeDatabase creates a new SQLVolumeDatabase, saving the database at dbPath.
+func NewSQLiteVolumeDatabase(dbPath string) SQLVolumeDatabase {
 
 	// If the database path was not set, then we are resposible for managing it.
 	if dbPath == "" {
@@ -42,5 +44,5 @@ func NewSQLiteVolumeDatabase(dbPath string) SQLVolumeDatabase {
 	}
 
 	// Create the connection
-	return NewSQLVolumeDatabase("sqlite3", path.Join(dbPath, "db"), VolumeDatabaseQueries{})
+	return NewSQLVolumeDatabase("sqlite3", path.Join(dbPath, "db"), SQLiteSQLOverrides)
 }

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -28,8 +28,8 @@ type StorageController interface {
 }
 
 // NewRDMAVolumeDriver constructs a new RDMAVolumeDriver.
-func NewRDMAVolumeDriver(sc StorageController, vd db.VolumeDatabase) RDMAVolumeDriver {
-	return RDMAVolumeDriver{sc, vd}
+func NewRDMAVolumeDriver(storageController StorageController, volumeDatabase db.VolumeDatabase) RDMAVolumeDriver {
+	return RDMAVolumeDriver{storageController, volumeDatabase}
 }
 
 func (r RDMAVolumeDriver) validateOrCrash() {

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -8,24 +8,27 @@ import (
 
 // RDMAVolumeDriver holds all the information pertaining to a RDMA Volume Driver.
 type RDMAVolumeDriver struct {
-	StorageController RDMAStorageController
+	StorageController StorageController
 	VolumeDatabase    db.VolumeDatabase
 }
 
-// RDMAStorageController interface allowing Storage Controllers to create, mounte, remove, ect. volumes on a host.
-type RDMAStorageController interface {
+// StorageController interface allowing Storage Controllers to create, mounte, remove, ect. volumes on a host.
+type StorageController interface {
 	Connect() error
 	Disconnect() error
 
-	// Mount a volume and mark that ID is using it, returning Mountpoint and error (nil if no error).
-	Mount(volumeName string, id string) (string, error)
+	// Mount a volume, returning Mountpoint and error (nil if no error).
+	Mount(volumeName string) (string, error)
 
-	// Unmount a volume from the host (NOT DELETE) if there are no longer any other ID's asking for the volume, returning error (nil if no error).
-	Unmount(volumeName string, id string) error
+	// Unmount a volume from the host (NOT DELETE).
+	Unmount(volumeName string) error
+
+	// Delete a particular volume
+	Delete(volumeName string) error
 }
 
 // NewRDMAVolumeDriver constructs a new RDMAVolumeDriver.
-func NewRDMAVolumeDriver(sc RDMAStorageController, vd db.VolumeDatabase) RDMAVolumeDriver {
+func NewRDMAVolumeDriver(sc StorageController, vd db.VolumeDatabase) RDMAVolumeDriver {
 	return RDMAVolumeDriver{sc, vd}
 }
 
@@ -168,7 +171,10 @@ func (r RDMAVolumeDriver) Remove(request volume.Request) volume.Response {
 	// TODO unmount all mounts before remove
 
 	// Pass the remove request to the volume database.
-	err := r.VolumeDatabase.Remove(request.Name)
+	err := r.StorageController.Delete(request.Name)
+	if err == nil {
+		err = r.VolumeDatabase.Remove(request.Name)
+	}
 
 	// If there was an error, log.
 	var errString string
@@ -234,11 +240,13 @@ func (r RDMAVolumeDriver) Mount(request volume.MountRequest) volume.Response {
 	// Ensure the r is properly confiured
 	r.validateOrCrash()
 
-	// Pass the mount request to the volume database.
-	mountpoint, err := r.VolumeDatabase.Mount(request.Name, request.ID)
-
 	// Pass the mount request to the storage controller.
-	// TODO mountpoint, err := r.StorageController.Mount(request.Name, request.ID)
+	mountpoint, err := r.StorageController.Mount(request.Name)
+	if err == nil {
+
+		// Pass the mount request to the volume database.
+		err = r.VolumeDatabase.Mount(request.Name, request.ID, mountpoint)
+	}
 
 	// If there was an error, log.
 	var errString string
@@ -272,9 +280,10 @@ func (r RDMAVolumeDriver) Unmount(request volume.UnmountRequest) volume.Response
 
 	// Pass the unmount request to the volume database.
 	err := r.VolumeDatabase.Unmount(request.Name, request.ID)
-
-	// Pass the unmount request to the storage controller.
-	// TODO err := r.StorageController.Unmount(request.Name, request.ID)
+	if err == nil {
+		// Pass the unmount request to the storage controller.
+		err = r.StorageController.Unmount(request.Name)
+	}
 
 	// If there was an error, log.
 	if err != nil {

--- a/drivers/glusterfs.go
+++ b/drivers/glusterfs.go
@@ -15,14 +15,14 @@ func (g GlusterStorageController) Disconnect() error {
 	return nil
 }
 
-func (g GlusterStorageController) Path(volumeName string) (string, error) {
+func (g GlusterStorageController) Mount(volumeName string) (string, error) {
 	return "", nil
 }
 
-func (g GlusterStorageController) Mount(volumeName string, id string) (string, error) {
-	return "/some/path/here", nil
+func (g GlusterStorageController) Unmount(volumeName string) error {
+	return nil
 }
 
-func (g GlusterStorageController) Unmount(volumeName string, id string) error {
+func (g GlusterStorageController) Delete(volumeName string) error {
 	return nil
 }

--- a/drivers/ondisk.go
+++ b/drivers/ondisk.go
@@ -120,9 +120,9 @@ func (d OnDiskStorageController) Delete(volumeName string) error {
 	}
 
 	_, err = os.Open(pathMounted)
-	if err != nil {
-		return err
+	if err == nil {
+		return os.Remove(pathMounted)
 	}
 
-	return os.Remove(pathMounted)
+	return nil
 }

--- a/drivers/ondisk.go
+++ b/drivers/ondisk.go
@@ -1,0 +1,128 @@
+package drivers
+
+import (
+	"errors"
+	"os"
+	"path"
+
+	"github.com/golang/glog"
+)
+
+// OnDiskStorageController is a way of testing the StorageController backend to ensure that all of the logic is correct.
+type OnDiskStorageController struct {
+	FSPath string
+}
+
+// NewOnDiskStorageController creates a new OnDiskStorageController
+func NewOnDiskStorageController(path string) OnDiskStorageController {
+
+	warning := `
+********************************************************************************
+*                                                                              *
+*                                WARNING!!!                                    *
+*             DO NOT USE the "On-Disk Controller" IN PRODUCTION!               *
+*                                                                              *
+*        You are currently using the On-Disk Storage Controller, it            *
+*        operates on the host's disk with out the benifits of rdma and         *
+*        should only be used for testing purposes. All data saved in           *
+*        the volumes will still be available by manually accessing the         *
+*        data in the host's filesystem.                                        *
+*                                                                              *
+********************************************************************************
+	`
+
+	glog.Warning(warning)
+
+	if path == "" {
+		path = "/etc/docker/mounts/"
+	}
+
+	_, err := os.Open(path)
+	if err != nil {
+		os.MkdirAll(path, 0755)
+		_, err = os.Open(path)
+		if err != nil {
+			glog.Fatal("Unable to create folder ", path, ". ", err)
+		}
+	}
+
+	return OnDiskStorageController{path}
+}
+
+// Connect is a NOOP
+func (d OnDiskStorageController) Connect() error {
+	glog.Info("Connect function called, no action taken.")
+	return nil
+}
+
+// Disconnect is a NOOP
+func (d OnDiskStorageController) Disconnect() error {
+	glog.Info("Disconnect function called, no action taken.")
+	return nil
+}
+
+// Mount a particular volume
+func (d OnDiskStorageController) Mount(volumeName string) (string, error) {
+	pathMounted := path.Join(d.FSPath, volumeName)
+	pathUnmounted := path.Join(path.Dir(pathMounted), path.Base(pathMounted)+".unmounted")
+
+	// If there is an unmounted volume, return it.
+	_, err := os.Open(pathUnmounted)
+	if err == nil {
+		glog.Info("Renaming: ", pathMounted, " to ", pathUnmounted)
+		return pathMounted, os.Rename(pathUnmounted, pathMounted)
+	}
+
+	_, err = os.Open(pathMounted)
+	if err != nil {
+		glog.Info("Creating: ", pathMounted)
+		os.MkdirAll(pathMounted, 0755)
+		_, err = os.Open(pathMounted)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return pathMounted, nil
+}
+
+// Unmount a particular volume
+func (d OnDiskStorageController) Unmount(volumeName string) error {
+	pathMounted := path.Join(d.FSPath, volumeName)
+	pathUnmounted := path.Join(path.Dir(pathMounted), path.Base(pathMounted)+".unmounted")
+
+	glog.Info(pathMounted)
+
+	// If there is an unmounted volume, return it.
+	_, err := os.Open(pathMounted)
+	if err == nil {
+		glog.Info("Renaming: ", pathMounted, " to ", pathUnmounted)
+		return os.Rename(pathMounted, pathUnmounted)
+	}
+
+	_, err = os.Open(pathUnmounted)
+	if err != nil {
+		return err
+	}
+
+	return errors.New("Already unmounted.")
+}
+
+// Delete a particular volume
+func (d OnDiskStorageController) Delete(volumeName string) error {
+	pathMounted := path.Join(d.FSPath, volumeName)
+	pathUnmounted := path.Join(path.Dir(pathMounted), path.Base(pathMounted)+".unmounted")
+
+	// If there is an unmounted volume, return it.
+	_, err := os.Open(pathUnmounted)
+	if err == nil {
+		return os.Remove(pathUnmounted)
+	}
+
+	_, err = os.Open(pathMounted)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(pathMounted)
+}

--- a/main.go
+++ b/main.go
@@ -58,20 +58,20 @@ func main() {
 	port := strconv.Itoa(httpPort)
 
 	// Create and begin serving volume driver on tcp/ip port, httpPort.
-	vd, dberr := getDatabaseConnection()
-	if dberr != nil {
-		glog.Fatal(dberr)
+	volumeDriver, err := getDatabaseConnection()
+	if err != nil {
+		glog.Fatal(err)
 	}
 
 	// Configure Storage Controller
-	sc, scerr := getStorageConnection()
-	if scerr != nil {
-		glog.Fatal(scerr)
+	storageController, err := getStorageConnection()
+	if err != nil {
+		glog.Fatal(err)
 	}
 
 	// Print startup message and start server
 	glog.Info("Connecting to services ...")
-	driver := drivers.NewRDMAVolumeDriver(sc, vd)
+	driver := drivers.NewRDMAVolumeDriver(storageController, volumeDriver)
 	driver.Connect()
 	defer driver.Disconnect()
 
@@ -86,8 +86,8 @@ func main() {
 	}()
 
 	glog.Info("Running! http://localhost:" + port)
-	h := volume.NewHandler(driver)
-	err := h.ServeTCP("test_volume", ":"+port, nil)
+	handler := volume.NewHandler(driver)
+	err = handler.ServeTCP("test_volume", ":"+port, nil)
 
 	// Log any error that may have occurred.
 	glog.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -140,11 +140,11 @@ func getStorageConnection() (drivers.StorageController, error) {
 
 	switch storageControllerDriver {
 	case "on-disk":
-		validateStorageFlags(true, false)
+		validateStorageFlags(true, true)
 		return drivers.NewOnDiskStorageController(storageControllerPath), nil
 
 	case "glusterfs":
-		validateStorageFlags(false, true)
+		validateStorageFlags(false, false)
 		return drivers.NewGlusterStorageController(), nil
 
 	default:


### PR DESCRIPTION
We need a way to communicate with different storage controllers, just in case one is better than the other.

Drivers:
* `on-disk`: Creates volumes as folders. For testing only.
* `glusterfs`: **TODO** Connects to glusterfs

Example:
```
./run.sh -sc="on-disk" -scpath=(path, defaults to /etc/docker/mounts)
```
> Starts the plugin writing to the disk. By default the path is /etc/docker/mounts, but can be changed with `-scpath=/your/folder/here`.

**NOT PRODUCTION READY**