### PR TITLE
Fix test script to actually fail if errors are detected

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,11 +14,16 @@ GIT_BRANCH=$(
 	sed 's#[^a-z0-9._-]#-#'
 )
 
-set -e
+failures=0
+
+function failure() {
+	red "$@"
+	failures=$((failed + 1))
+}
 
 green Unit Tests
 if ! docker build --tag docker-volume-rdma:"$GIT_BRANCH" .; then
-	red 'Failed to run unit tests'
+	failure 'Failed to run unit tests'
 fi
 docker rmi docker-volume-rdma:"$GIT_BRANCH"
 
@@ -30,6 +35,8 @@ for scenario in $(cd ./benchmarking; ls -d */ | grep -v '^scenarios/?$' | sed 's
 	echo # make space
 	sleep 5
 	if ! ./benchmarking/test.sh "$scenario"; then
-		red 'Failed to run benchmarks'
+		failure 'Failed to run benchmarks'
 	fi
 done
+
+exit $failures


### PR DESCRIPTION
Currently the CI benchmarks check only fails if there's an error in the script, ignoring actual test failures. This fixes that by tallying up the number of tests that failed and eventually failing the build.